### PR TITLE
[Feature/#28] OCR 전처리 방법 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,11 @@ dependencies {
     // ocr
     implementation 'net.sourceforge.tess4j:tess4j:5.13.0'
 
+    // OpenCV + JavaCV with native bindings
+    implementation 'org.bytedeco:javacv-platform:1.5.9'
+    implementation 'org.bytedeco:opencv-platform:4.7.0-1.5.9'
+    implementation "org.bytedeco:openblas-platform:0.3.23-1.5.9"
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/goorm/veri/veribe/domain/image/controller/ImageController.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/image/controller/ImageController.java
@@ -34,7 +34,7 @@ public class ImageController {
             @AuthenticatedMember Member member,
             @RequestParam("imageUrl") String imageUrl) throws Exception {
 
-        return DefaultResponse.ok(imageCmdService.processImageOcrAndSave(imageUrl, member));
+        return DefaultResponse.ok(imageCmdService.processImageOcrAndSave(member, imageUrl));
     }
 
     @Operation(summary = "업로드 이미지 목록 조회", description = "내가 업로드한 이미지 파일 목록을 페이지네이션으로 조회합니다.")

--- a/src/main/java/org/goorm/veri/veribe/domain/image/exception/ImageErrorCode.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/image/exception/ImageErrorCode.java
@@ -13,10 +13,9 @@ public enum ImageErrorCode implements BaseErrorCode {
     NOT_FOUND(HttpStatus.NOT_FOUND, "IMG404", "해당 이미지를 찾을 수 없습니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "IMG400", "잘못된 요청입니다. 요청을 확인해주세요."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "IMG401", "해당 이미지에 대한 권한이 없습니다."),
-    ENCODING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "IMG500_1", "이미지 인코딩에 실패했습니다."),
+    CROP_RANGE_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "IMG500_1", "크롭된 이미지의 좌표 및 높낮이 값이 유효하지 않습니다."),
     SIZE_EXCEEDED(HttpStatus.INTERNAL_SERVER_ERROR, "IMG500_2", "이미지 크기는 1MB를 초과할 수 없습니다."),
-    UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "IMG500_3", "S3 업로드에 실패했습니다."),
-    UNSUPPORTED_TYPE(HttpStatus.INTERNAL_SERVER_ERROR, "IMG500_4", "지원하지 않는 파일 형식입니다.");
+    UNSUPPORTED_TYPE(HttpStatus.INTERNAL_SERVER_ERROR, "IMG500_3", "지원하지 않는 파일 형식입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/org/goorm/veri/veribe/domain/image/service/ImageCommandService.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/image/service/ImageCommandService.java
@@ -3,5 +3,5 @@ package org.goorm.veri.veribe.domain.image.service;
 import org.goorm.veri.veribe.domain.member.entity.Member;
 
 public interface ImageCommandService {
-    String processImageOcrAndSave(String imageUrl, Member member) throws Exception;
+    String processImageOcrAndSave(Member member, String imageUrl) throws Exception;
 }

--- a/src/main/java/org/goorm/veri/veribe/domain/image/service/ImageCommandServiceImpl.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/image/service/ImageCommandServiceImpl.java
@@ -17,7 +17,6 @@ import org.goorm.veri.veribe.global.data.OcrConfigData;
 import org.springframework.stereotype.Service;
 
 import javax.imageio.ImageIO;
-import java.awt.*;
 import java.awt.image.BufferedImage;
 
 import java.io.IOException;
@@ -95,7 +94,7 @@ public class ImageCommandServiceImpl implements ImageCommandService {
         Tesseract tesseract = new Tesseract();
         tesseract.setDatapath(ocrConfigData.getTessdataPath());
         tesseract.setLanguage(ocrConfigData.getLanguage());
-        tesseract.setPageSegMode(6);
+        tesseract.setPageSegMode(11);
 
         return tesseract;
     }

--- a/src/main/java/org/goorm/veri/veribe/domain/image/service/ImageQueryService.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/image/service/ImageQueryService.java
@@ -1,11 +1,12 @@
 package org.goorm.veri.veribe.domain.image.service;
 
 import org.goorm.veri.veribe.domain.image.dto.response.PageResponse;
+import org.goorm.veri.veribe.domain.member.entity.Member;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 
 public interface ImageQueryService {
-    PageResponse<List<String>> fetchUploadedImages(Long userId, Pageable pageable);
+    PageResponse<List<String>> fetchUploadedImages(Member member, Pageable pageable);
 }

--- a/src/main/java/org/goorm/veri/veribe/domain/image/service/ImageQueryService.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/image/service/ImageQueryService.java
@@ -8,5 +8,5 @@ import java.util.List;
 
 
 public interface ImageQueryService {
-    PageResponse<List<String>> fetchUploadedImages(Member member, Pageable pageable);
+    PageResponse<List<String>> fetchUploadedImages(Long memberId, Pageable pageable);
 }

--- a/src/main/java/org/goorm/veri/veribe/domain/image/service/ImageQueryServiceImpl.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/image/service/ImageQueryServiceImpl.java
@@ -2,18 +2,12 @@ package org.goorm.veri.veribe.domain.image.service;
 
 import lombok.RequiredArgsConstructor;
 import org.goorm.veri.veribe.domain.image.dto.response.PageResponse;
-import org.goorm.veri.veribe.domain.image.exception.ImageErrorCode;
-import org.goorm.veri.veribe.domain.image.exception.ImageException;
 import org.goorm.veri.veribe.domain.image.repository.ImageRepository;
+import org.goorm.veri.veribe.domain.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-
-
-import java.io.IOException;
-import java.net.URL;
-import java.util.Base64;
 import java.util.List;
 
 @Service
@@ -22,8 +16,8 @@ public class ImageQueryServiceImpl implements ImageQueryService{
     private final ImageRepository imageRepository;
 
     @Override
-    public PageResponse<List<String>> fetchUploadedImages(Long userId, Pageable pageable) {
-        Page<String> imageUrls = imageRepository.findByMemberId(userId, pageable);
+    public PageResponse<List<String>> fetchUploadedImages(Member member, Pageable pageable) {
+        Page<String> imageUrls = imageRepository.findByMemberId(member.getId(), pageable);
 
         if(imageUrls.isEmpty()){
             return PageResponse.empty(pageable);

--- a/src/main/java/org/goorm/veri/veribe/domain/image/service/ImageQueryServiceImpl.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/image/service/ImageQueryServiceImpl.java
@@ -16,8 +16,8 @@ public class ImageQueryServiceImpl implements ImageQueryService{
     private final ImageRepository imageRepository;
 
     @Override
-    public PageResponse<List<String>> fetchUploadedImages(Member member, Pageable pageable) {
-        Page<String> imageUrls = imageRepository.findByMemberId(member.getId(), pageable);
+    public PageResponse<List<String>> fetchUploadedImages(Long memberId, Pageable pageable) {
+        Page<String> imageUrls = imageRepository.findByMemberId(memberId, pageable);
 
         if(imageUrls.isEmpty()){
             return PageResponse.empty(pageable);


### PR DESCRIPTION
- OpenCV 기반 전처리로 변경
- 기존: 컬러 이미지를 Java2D로 흑백 처리(그레이 스케일) 하여 OCR
- 신규
1. 기존 방식 유지
2. BuffedImage를 Mat 형식으로 변환 ( OpenCV는 Mat 형식 만을 처리. )
```
Mat matGray = converterToMat.convert(converterToFrame.convert(gray));
```
3. 가우시안 블러 ( 이미지의 노이즈 제거 )
```
opencv_imgproc.GaussianBlur(matGray, matGray, new Size(3, 3), 0);
```
4. 이미지 이진화 ( 이미지 픽셀을 흑과 백으로만 나누어 Tesseract가 텍스트와 배경을 구분하기 쉽게 함. BlockSize와 C 값은 실험적인 방법으로 결정. )
```
Mat binary = new Mat();
opencv_imgproc.adaptiveThreshold(
                    matGray,
                    binary,
                    255,
                    opencv_imgproc.ADAPTIVE_THRESH_MEAN_C,
                    opencv_imgproc.THRESH_BINARY,
                    17,   // blockSize (홀수만 가능, 15~25 사이 실험 추천)
                    7    // C 값 (조정값, 작을수록 더 민감)
            );
```