### PR TITLE
카드 API 수정 / 각종 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,7 @@ out/
 .vscode/
 
 ### yml ###
-application.yml
+application*.yml
 application.properties
+
+.env

--- a/src/main/java/org/goorm/veri/veribe/domain/book/controller/BookshelfController.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/book/controller/BookshelfController.java
@@ -17,7 +17,10 @@ import org.goorm.veri.veribe.domain.member.entity.Member;
 import org.namul.api.payload.response.DefaultResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
+@Tag(name = "책장 API", description = "책장(내 서재) 관련 API")
 @RequestMapping("/api/v0/bookshelf")
 @RestController
 @RequiredArgsConstructor
@@ -26,6 +29,7 @@ public class BookshelfController {
     private final BookshelfService bookshelfService;
     private final BookService bookService;
 
+    @Operation(summary = "책장에 책 추가", description = "신규 도서를 등록하고 내 책장에 추가합니다.")
     @PostMapping
     public DefaultResponse<MemberBookAddResponse> addBook(@RequestBody BookRequest request, @AuthenticatedMember Member member) {
 
@@ -41,6 +45,7 @@ public class BookshelfController {
         return DefaultResponse.created(new MemberBookAddResponse(memberBook.getId(), memberBook.getCreatedAt()));
     }
 
+    @Operation(summary = "내 책장 전체 조회", description = "내 책장에 등록된 모든 책을 페이지네이션과 정렬 기준으로 조회합니다.")
     @GetMapping("/all")
     public DefaultResponse<MemberBookListResponse> getAllBooks(
             @RequestParam(defaultValue = "1") @Min(1) int page,
@@ -54,6 +59,7 @@ public class BookshelfController {
         return DefaultResponse.ok(new MemberBookListResponse(pageData));
     }
 
+    @Operation(summary = "책장 상세 조회", description = "memberBookId로 책장에 등록된 책의 상세 정보를 조회합니다.")
     @GetMapping("/detail")
     public DefaultResponse<MemberBookDetailResponse> getBookDetail(@RequestParam Long memberBookId) {
         MemberBookDetailResponse result = bookshelfService.searchDetail(memberBookId);
@@ -61,6 +67,7 @@ public class BookshelfController {
         return DefaultResponse.ok(result);
     }
 
+    @Operation(summary = "도서 검색", description = "검색어로 도서를 검색합니다.")
     @GetMapping("/search")
     public DefaultResponse<BookSearchResponse> searchBooks(
             @RequestParam String query,
@@ -72,6 +79,7 @@ public class BookshelfController {
         return DefaultResponse.ok(bookResponses);
     }
 
+    @Operation(summary = "인기 도서 조회", description = "인기 도서 목록을 페이지네이션으로 조회합니다.")
     @GetMapping("/popular")
     public DefaultResponse<BookPopularListResponse> getPopularBooks(
             @RequestParam(defaultValue = "1") @Min(1) int page,
@@ -82,6 +90,7 @@ public class BookshelfController {
         return DefaultResponse.ok(new BookPopularListResponse(pageData));
     }
 
+    @Operation(summary = "내 완독 책 개수 조회", description = "내가 완독한 책의 개수를 조회합니다.")
     @GetMapping("/my/count")
     public DefaultResponse<Integer> getMyBookCount(@AuthenticatedMember Member member) {
         Integer count = bookshelfService.searchMyReadingDoneCount(member.getId());
@@ -89,6 +98,7 @@ public class BookshelfController {
         return DefaultResponse.ok(count);
     }
 
+    @Operation(summary = "책 평점 등록/수정", description = "책장에 등록된 책의 평점을 등록 또는 수정합니다.")
     @PatchMapping("/rate")
     public DefaultResponse<Void> rateBook(
             @RequestBody @Valid MemberBookScoreRequest request,
@@ -98,6 +108,7 @@ public class BookshelfController {
         return DefaultResponse.noContent();
     }
 
+    @Operation(summary = "독서 시작 상태 변경", description = "책장에 등록된 책의 상태를 '읽는 중'으로 변경합니다.")
     @PatchMapping("/status/start")
     public DefaultResponse<Void> startReading(@RequestParam Long memberBookId) {
         bookshelfService.readStart(memberBookId);
@@ -105,6 +116,7 @@ public class BookshelfController {
         return DefaultResponse.noContent();
     }
 
+    @Operation(summary = "독서 완료 상태 변경", description = "책장에 등록된 책의 상태를 '완독'으로 변경합니다.")
     @PatchMapping("/status/over")
     public DefaultResponse<Void> finishReading(@RequestParam Long memberBookId) {
         bookshelfService.readOver(memberBookId);
@@ -112,6 +124,7 @@ public class BookshelfController {
         return DefaultResponse.noContent();
     }
 
+    @Operation(summary = "책장 도서 삭제", description = "책장에 등록된 책을 삭제합니다.")
     @DeleteMapping
     public DefaultResponse<Void> deleteFromBookshelf(@RequestParam Long memberBookId) {
         bookshelfService.deleteBook(memberBookId);

--- a/src/main/java/org/goorm/veri/veribe/domain/book/controller/BookshelfControllerV2.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/book/controller/BookshelfControllerV2.java
@@ -5,23 +5,35 @@ import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.goorm.veri.veribe.domain.auth.annotation.AuthenticatedMember;
 import org.goorm.veri.veribe.domain.book.controller.enums.MemberBookSortType;
-import org.goorm.veri.veribe.domain.book.dto.book.BookPopularListResponse;
+import org.goorm.veri.veribe.domain.book.dto.book.BookPopularListResponseV2;
 import org.goorm.veri.veribe.domain.book.dto.book.BookPopularResponse;
 import org.goorm.veri.veribe.domain.book.dto.book.BookRequest;
 import org.goorm.veri.veribe.domain.book.dto.book.BookSearchResponse;
-import org.goorm.veri.veribe.domain.book.dto.memberBook.*;
+import org.goorm.veri.veribe.domain.book.dto.memberBook.MemberBookAddResponse;
+import org.goorm.veri.veribe.domain.book.dto.memberBook.MemberBookDetailResponse;
+import org.goorm.veri.veribe.domain.book.dto.memberBook.MemberBookListResponse;
+import org.goorm.veri.veribe.domain.book.dto.memberBook.MemberBookResponse;
+import org.goorm.veri.veribe.domain.book.dto.memberBook.MemberBookScoreRequest;
 import org.goorm.veri.veribe.domain.book.entity.MemberBook;
 import org.goorm.veri.veribe.domain.book.service.BookService;
 import org.goorm.veri.veribe.domain.book.service.BookshelfService;
 import org.goorm.veri.veribe.domain.member.entity.Member;
 import org.namul.api.payload.response.DefaultResponse;
 import org.springframework.data.domain.Page;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-@RequestMapping("/api/v0/bookshelf")
+@RequestMapping("/api/v2/bookshelf")
 @RestController
 @RequiredArgsConstructor
-public class BookshelfController {
+public class BookshelfControllerV2 {
 
     private final BookshelfService bookshelfService;
     private final BookService bookService;
@@ -41,7 +53,7 @@ public class BookshelfController {
         return DefaultResponse.created(new MemberBookAddResponse(memberBook.getId(), memberBook.getCreatedAt()));
     }
 
-    @GetMapping("/all")
+    @GetMapping("/my")
     public DefaultResponse<MemberBookListResponse> getAllBooks(
             @RequestParam(defaultValue = "1") @Min(1) int page,
             @RequestParam(defaultValue = "10") @Min(1) int size,
@@ -54,8 +66,8 @@ public class BookshelfController {
         return DefaultResponse.ok(new MemberBookListResponse(pageData));
     }
 
-    @GetMapping("/detail")
-    public DefaultResponse<MemberBookDetailResponse> getBookDetail(@RequestParam Long memberBookId) {
+    @GetMapping("/{memberBookId}")
+    public DefaultResponse<MemberBookDetailResponse> getBookDetail(@PathVariable Long memberBookId) {
         MemberBookDetailResponse result = bookshelfService.searchDetail(memberBookId);
 
         return DefaultResponse.ok(result);
@@ -73,13 +85,10 @@ public class BookshelfController {
     }
 
     @GetMapping("/popular")
-    public DefaultResponse<BookPopularListResponse> getPopularBooks(
-            @RequestParam(defaultValue = "1") @Min(1) int page,
-            @RequestParam(defaultValue = "10") @Min(1) int size
-    ) {
-        Page<BookPopularResponse> pageData = bookshelfService.searchPopular(page, size);
+    public DefaultResponse<BookPopularListResponseV2> getPopularBooks() {
+        Page<BookPopularResponse> pageData = bookshelfService.searchPopular(0, 10); // 상위 10개
 
-        return DefaultResponse.ok(new BookPopularListResponse(pageData));
+        return DefaultResponse.ok(new BookPopularListResponseV2(pageData.getContent()));
     }
 
     @GetMapping("/my/count")
@@ -89,31 +98,31 @@ public class BookshelfController {
         return DefaultResponse.ok(count);
     }
 
-    @PatchMapping("/rate")
+    @PatchMapping("/{memberBookId}/rate")
     public DefaultResponse<Void> rateBook(
             @RequestBody @Valid MemberBookScoreRequest request,
-            @RequestParam Long memberBookId) {
+            @PathVariable Long memberBookId) {
         bookshelfService.rateScore(request.score(), memberBookId);
 
         return DefaultResponse.noContent();
     }
 
-    @PatchMapping("/status/start")
-    public DefaultResponse<Void> startReading(@RequestParam Long memberBookId) {
+    @PatchMapping("/{memberBookId}/status/start")
+    public DefaultResponse<Void> startReading(@PathVariable Long memberBookId) {
         bookshelfService.readStart(memberBookId);
 
         return DefaultResponse.noContent();
     }
 
-    @PatchMapping("/status/over")
-    public DefaultResponse<Void> finishReading(@RequestParam Long memberBookId) {
+    @PatchMapping("/{memberBookId}/status/over")
+    public DefaultResponse<Void> finishReading(@PathVariable Long memberBookId) {
         bookshelfService.readOver(memberBookId);
 
         return DefaultResponse.noContent();
     }
 
-    @DeleteMapping
-    public DefaultResponse<Void> deleteFromBookshelf(@RequestParam Long memberBookId) {
+    @DeleteMapping("/{memberBookId}")
+    public DefaultResponse<Void> deleteFromBookshelf(@PathVariable Long memberBookId) {
         bookshelfService.deleteBook(memberBookId);
 
         return DefaultResponse.noContent();

--- a/src/main/java/org/goorm/veri/veribe/domain/book/controller/BookshelfControllerV2.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/book/controller/BookshelfControllerV2.java
@@ -29,7 +29,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
+@Tag(name = "책장 API V2")
 @RequestMapping("/api/v2/bookshelf")
 @RestController
 @RequiredArgsConstructor
@@ -38,6 +41,7 @@ public class BookshelfControllerV2 {
     private final BookshelfService bookshelfService;
     private final BookService bookService;
 
+    @Operation(summary = "책장에 책 추가", description = "신규 도서를 등록하고 내 책장에 추가합니다.")
     @PostMapping
     public DefaultResponse<MemberBookAddResponse> addBook(@RequestBody BookRequest request, @AuthenticatedMember Member member) {
 
@@ -53,6 +57,7 @@ public class BookshelfControllerV2 {
         return DefaultResponse.created(new MemberBookAddResponse(memberBook.getId(), memberBook.getCreatedAt()));
     }
 
+    @Operation(summary = "내 책장 전체 조회", description = "내 책장에 등록된 모든 책을 페이지네이션과 정렬 기준으로 조회합니다.")
     @GetMapping("/my")
     public DefaultResponse<MemberBookListResponse> getAllBooks(
             @RequestParam(defaultValue = "1") @Min(1) int page,
@@ -66,6 +71,7 @@ public class BookshelfControllerV2 {
         return DefaultResponse.ok(new MemberBookListResponse(pageData));
     }
 
+    @Operation(summary = "책장 상세 조회", description = "memberBookId로 책장에 등록된 책의 상세 정보를 조회합니다.")
     @GetMapping("/{memberBookId}")
     public DefaultResponse<MemberBookDetailResponse> getBookDetail(@PathVariable Long memberBookId) {
         MemberBookDetailResponse result = bookshelfService.searchDetail(memberBookId);
@@ -73,6 +79,7 @@ public class BookshelfControllerV2 {
         return DefaultResponse.ok(result);
     }
 
+    @Operation(summary = "도서 검색", description = "검색어로 도서를 검색합니다.")
     @GetMapping("/search")
     public DefaultResponse<BookSearchResponse> searchBooks(
             @RequestParam String query,
@@ -84,6 +91,7 @@ public class BookshelfControllerV2 {
         return DefaultResponse.ok(bookResponses);
     }
 
+    @Operation(summary = "인기 도서 조회", description = "인기 도서 상위 10개를 조회합니다.")
     @GetMapping("/popular")
     public DefaultResponse<BookPopularListResponseV2> getPopularBooks() {
         Page<BookPopularResponse> pageData = bookshelfService.searchPopular(0, 10); // 상위 10개
@@ -91,6 +99,7 @@ public class BookshelfControllerV2 {
         return DefaultResponse.ok(new BookPopularListResponseV2(pageData.getContent()));
     }
 
+    @Operation(summary = "내 완독 책 개수 조회", description = "내가 완독한 책의 개수를 조회합니다.")
     @GetMapping("/my/count")
     public DefaultResponse<Integer> getMyBookCount(@AuthenticatedMember Member member) {
         Integer count = bookshelfService.searchMyReadingDoneCount(member.getId());
@@ -98,6 +107,7 @@ public class BookshelfControllerV2 {
         return DefaultResponse.ok(count);
     }
 
+    @Operation(summary = "책 평점 등록/수정", description = "책장에 등록된 책의 평점을 등록 또는 수정합니다.")
     @PatchMapping("/{memberBookId}/rate")
     public DefaultResponse<Void> rateBook(
             @RequestBody @Valid MemberBookScoreRequest request,
@@ -107,6 +117,7 @@ public class BookshelfControllerV2 {
         return DefaultResponse.noContent();
     }
 
+    @Operation(summary = "독서 시작 상태 변경", description = "책장에 등록된 책의 상태를 '읽는 중'으로 변경합니다.")
     @PatchMapping("/{memberBookId}/status/start")
     public DefaultResponse<Void> startReading(@PathVariable Long memberBookId) {
         bookshelfService.readStart(memberBookId);
@@ -114,6 +125,7 @@ public class BookshelfControllerV2 {
         return DefaultResponse.noContent();
     }
 
+    @Operation(summary = "독서 완료 상태 변경", description = "책장에 등록된 책의 상태를 '완독'으로 변경합니다.")
     @PatchMapping("/{memberBookId}/status/over")
     public DefaultResponse<Void> finishReading(@PathVariable Long memberBookId) {
         bookshelfService.readOver(memberBookId);
@@ -121,6 +133,7 @@ public class BookshelfControllerV2 {
         return DefaultResponse.noContent();
     }
 
+    @Operation(summary = "책장 도서 삭제", description = "책장에 등록된 책을 삭제합니다.")
     @DeleteMapping("/{memberBookId}")
     public DefaultResponse<Void> deleteFromBookshelf(@PathVariable Long memberBookId) {
         bookshelfService.deleteBook(memberBookId);

--- a/src/main/java/org/goorm/veri/veribe/domain/book/dto/book/BookPopularListResponseV2.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/book/dto/book/BookPopularListResponseV2.java
@@ -1,0 +1,8 @@
+package org.goorm.veri.veribe.domain.book.dto.book;
+
+import java.util.List;
+
+public record BookPopularListResponseV2(
+        List<BookPopularResponse> books
+) {
+}

--- a/src/main/java/org/goorm/veri/veribe/domain/book/entity/MemberBook.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/book/entity/MemberBook.java
@@ -44,6 +44,7 @@ public class MemberBook extends BaseEntity {
     @Column(name = "status")
     private BookStatus status;
 
-    @OneToMany(mappedBy = "memberBook", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    @OneToMany(mappedBy = "memberBook")
     private List<Card> cards = new ArrayList<>();
 }

--- a/src/main/java/org/goorm/veri/veribe/domain/card/controller/CardController.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/card/controller/CardController.java
@@ -24,7 +24,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
+@Tag(name = "독서 카드 API")
 @RequestMapping("/api/v1/cards")
 @RestController
 @RequiredArgsConstructor
@@ -33,6 +36,7 @@ public class CardController {
     private final CardCommandService cardCommandService;
     private final CardQueryService cardQueryService;
 
+    @Operation(summary = "카드 생성", description = "카드를 새로 생성합니다.")
     @PostMapping
     public DefaultResponse<CardCreateResponse> createCard(
             @RequestBody CardCreateRequest request,
@@ -47,11 +51,13 @@ public class CardController {
         return DefaultResponse.created(new CardCreateResponse(cardId));
     }
 
+    @Operation(summary = "내 카드 개수 조회", description = "로그인한 사용자의 카드 개수를 조회합니다.")
     @GetMapping("/my/count")
     public DefaultResponse<Integer> getMyCardCount(@AuthenticatedMember Member member) {
         return DefaultResponse.ok(cardQueryService.getOwnedCardCount(member.getId()));
     }
 
+    @Operation(summary = "내 카드 목록 조회", description = "로그인한 사용자의 카드 목록을 페이지네이션과 정렬 기준으로 조회합니다.")
     @GetMapping("/my")
     public DefaultResponse<CardListResponse> getMyCards(
             @AuthenticatedMember Member member,
@@ -66,12 +72,14 @@ public class CardController {
         );
     }
 
+    @Operation(summary = "카드 상세 조회", description = "카드 ID로 카드의 상세 정보를 조회합니다.")
     @GetMapping("/{cardId}")
     public DefaultResponse<CardDetailResponse> getCard(@PathVariable Long cardId) {
         Card card = cardQueryService.getCardById(cardId);
         return DefaultResponse.ok(CardConverter.toCardDetailResponse(card));
     }
 
+    @Operation(summary = "카드 삭제", description = "카드 ID로 카드를 삭제합니다. 본인 소유 카드만 삭제할 수 있습니다.")
     @DeleteMapping("/{cardId}")
     public DefaultResponse<Void> deleteCard(@PathVariable Long cardId,
                                             @AuthenticatedMember Member member) {
@@ -85,6 +93,7 @@ public class CardController {
      * <p>
      * 클라이언트에서 해당 url에 PUT 방식으로 이미지 업로드
      */
+    @Operation(summary = "카드 이미지 presigned URL 발급", description = "요청한 이미지 타입과 크기에 맞는 presigned URL을 발급합니다. 해당 URL로 PUT 방식 업로드가 가능합니다.")
     @PostMapping("/image")
     public DefaultResponse<PresignedUrlResponse> uploadCardImage(@RequestBody PresignedUrlRequest request) {
 

--- a/src/main/java/org/goorm/veri/veribe/domain/card/controller/CardController.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/card/controller/CardController.java
@@ -42,7 +42,7 @@ public class CardController {
             @RequestBody CardCreateRequest request,
             @AuthenticatedMember Member member) {
         Long cardId = cardCommandService.createCard(
-                member.getId(),
+                member,
                 request.content(),
                 request.imageUrl(),
                 request.memberBookId()

--- a/src/main/java/org/goorm/veri/veribe/domain/card/controller/CardControllerV2.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/card/controller/CardControllerV2.java
@@ -1,6 +1,8 @@
 package org.goorm.veri.veribe.domain.card.controller;
 
 import io.github.miensoap.s3.core.post.dto.PresignedPostForm;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.goorm.veri.veribe.domain.card.service.CardCommandService;
 import org.namul.api.payload.response.DefaultResponse;
@@ -8,6 +10,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "카드 API V2")
 @RequestMapping("/api/v2/cards")
 @RestController
 @RequiredArgsConstructor
@@ -21,6 +24,7 @@ public class CardControllerV2 {
      * <p>
      * 클라이언트에서 form-data 에 실제 이미지와 Content-Type을 수정하여 POST 방식 업로드
      */
+    @Operation(summary = "카드 presigned post form 발급", description = "image/* 타입의 1MB 이하 업로드를 위한 presigned post form을 발급합니다. 클라이언트에서 form-data에 실제 이미지와 Content-Type을 수정하여 POST 방식 업로드가 가능합니다.")
     @PostMapping("/image")
     public DefaultResponse<PresignedPostForm> uploadCardImageV2() {
         return DefaultResponse.ok(cardCommandService.getPresignedPost());

--- a/src/main/java/org/goorm/veri/veribe/domain/card/controller/dto/CardConverter.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/card/controller/dto/CardConverter.java
@@ -10,7 +10,7 @@ public class CardConverter {
                 card.getContent(),
                 card.getImage(),
                 card.getCreatedAt(),
-                new CardDetailResponse.BookInfo(card.getMemberBook())
+                CardDetailResponse.BookInfo.from(card.getMemberBook())
         );
     }
 }

--- a/src/main/java/org/goorm/veri/veribe/domain/card/controller/dto/CardConverter.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/card/controller/dto/CardConverter.java
@@ -9,6 +9,7 @@ public class CardConverter {
                 card.getId(),
                 card.getContent(),
                 card.getImage(),
+                card.getCreatedAt(),
                 new CardDetailResponse.BookInfo(card.getMemberBook().getBook())
         );
     }

--- a/src/main/java/org/goorm/veri/veribe/domain/card/controller/dto/CardConverter.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/card/controller/dto/CardConverter.java
@@ -10,7 +10,7 @@ public class CardConverter {
                 card.getContent(),
                 card.getImage(),
                 card.getCreatedAt(),
-                new CardDetailResponse.BookInfo(card.getMemberBook().getBook())
+                new CardDetailResponse.BookInfo(card.getMemberBook())
         );
     }
 }

--- a/src/main/java/org/goorm/veri/veribe/domain/card/controller/dto/CardDetailResponse.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/card/controller/dto/CardDetailResponse.java
@@ -18,8 +18,9 @@ public record CardDetailResponse(
             String coverImageUrl,
             String author
     ) {
-        public BookInfo(MemberBook memberBook) {
-            this(
+        public static BookInfo from(MemberBook memberBook) {
+            if (memberBook == null) return null;
+            return new BookInfo(
                     memberBook.getId(),
                     memberBook.getBook().getTitle(),
                     memberBook.getBook().getImage(),

--- a/src/main/java/org/goorm/veri/veribe/domain/card/controller/dto/CardDetailResponse.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/card/controller/dto/CardDetailResponse.java
@@ -2,10 +2,13 @@ package org.goorm.veri.veribe.domain.card.controller.dto;
 
 import org.goorm.veri.veribe.domain.book.entity.Book;
 
+import java.time.LocalDateTime;
+
 public record CardDetailResponse(
         Long id,
         String content,
         String imageUrl,
+        LocalDateTime createdAt,
         BookInfo book
 ) {
 

--- a/src/main/java/org/goorm/veri/veribe/domain/card/controller/dto/CardDetailResponse.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/card/controller/dto/CardDetailResponse.java
@@ -1,6 +1,6 @@
 package org.goorm.veri.veribe.domain.card.controller.dto;
 
-import org.goorm.veri.veribe.domain.book.entity.Book;
+import org.goorm.veri.veribe.domain.book.entity.MemberBook;
 
 import java.time.LocalDateTime;
 
@@ -13,15 +13,17 @@ public record CardDetailResponse(
 ) {
 
     record BookInfo(
+            Long id,
             String title,
             String coverImageUrl,
             String author
     ) {
-        public BookInfo(Book book) {
+        public BookInfo(MemberBook memberBook) {
             this(
-                    book.getTitle(),
-                    book.getImage(),
-                    book.getAuthor()
+                    memberBook.getId(),
+                    memberBook.getBook().getTitle(),
+                    memberBook.getBook().getImage(),
+                    memberBook.getBook().getAuthor()
             );
         }
     }

--- a/src/main/java/org/goorm/veri/veribe/domain/card/entity/Card.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/card/entity/Card.java
@@ -1,7 +1,21 @@
 package org.goorm.veri.veribe.domain.card.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.goorm.veri.veribe.domain.book.entity.MemberBook;
 import org.goorm.veri.veribe.global.entity.BaseEntity;
 
@@ -25,6 +39,16 @@ public class Card extends BaseEntity {
     private String image;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_book_id")
+    @JoinColumn(
+            name = "member_book_id",
+            foreignKey = @ForeignKey(
+                    name = "fk_card_member_book",
+                    value = ConstraintMode.CONSTRAINT,
+                    foreignKeyDefinition =
+                            "FOREIGN KEY (member_book_id) " +
+                                    "REFERENCES member_book(member_book_id) " +
+                                    "ON DELETE SET NULL"
+            )
+    )
     private MemberBook memberBook;
 }

--- a/src/main/java/org/goorm/veri/veribe/domain/card/entity/Card.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/card/entity/Card.java
@@ -17,6 +17,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.goorm.veri.veribe.domain.book.entity.MemberBook;
+import org.goorm.veri.veribe.domain.member.entity.Member;
 import org.goorm.veri.veribe.global.entity.BaseEntity;
 
 @Getter
@@ -51,4 +52,8 @@ public class Card extends BaseEntity {
             )
     )
     private MemberBook memberBook;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
 }

--- a/src/main/java/org/goorm/veri/veribe/domain/card/repository/CardRepository.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/card/repository/CardRepository.java
@@ -17,9 +17,9 @@ public interface CardRepository extends JpaRepository<Card, Long> {
 
     @Query("SELECT new org.goorm.veri.veribe.domain.card.repository.dto.CardListItem(c.id, c.content, c.image, c.createdAt) " +
             "FROM Card c " +
-            "WHERE c.memberBook.member.id = :memberId")
+            "WHERE c.member.id = :memberId")
     Page<CardListItem> findAllByMemberId(@Param("memberId") Long memberId, Pageable pageable);
 
-    @Query("SELECT COUNT(c) FROM Card c WHERE c.memberBook.member.id = :memberId")
+    @Query("SELECT COUNT(c) FROM Card c WHERE c.member.id = :memberId")
     int countAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/org/goorm/veri/veribe/domain/card/repository/CardRepository.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/card/repository/CardRepository.java
@@ -15,7 +15,7 @@ import java.util.List;
 @Repository
 public interface CardRepository extends JpaRepository<Card, Long> {
 
-    @Query("SELECT new org.goorm.veri.veribe.domain.card.repository.dto.CardListItem(c.id, c.content, c.image) " +
+    @Query("SELECT new org.goorm.veri.veribe.domain.card.repository.dto.CardListItem(c.id, c.content, c.image, c.createdAt) " +
             "FROM Card c " +
             "WHERE c.memberBook.member.id = :memberId")
     Page<CardListItem> findAllByMemberId(@Param("memberId") Long memberId, Pageable pageable);

--- a/src/main/java/org/goorm/veri/veribe/domain/card/repository/dto/CardListItem.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/card/repository/dto/CardListItem.java
@@ -3,10 +3,13 @@ package org.goorm.veri.veribe.domain.card.repository.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @AllArgsConstructor
 public class CardListItem {
     private Long cardId;
     private String content;
     private String image;
+    private LocalDateTime created;
 }

--- a/src/main/java/org/goorm/veri/veribe/domain/card/service/CardCommandService.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/card/service/CardCommandService.java
@@ -1,12 +1,13 @@
 package org.goorm.veri.veribe.domain.card.service;
 
 import io.github.miensoap.s3.core.post.dto.PresignedPostForm;
+import org.goorm.veri.veribe.domain.member.entity.Member;
 import org.goorm.veri.veribe.global.storage.dto.PresignedUrlRequest;
 import org.goorm.veri.veribe.global.storage.dto.PresignedUrlResponse;
 
 public interface CardCommandService {
 
-    Long createCard(Long memberId, String content, String imageUrl, Long memberBookId);
+    Long createCard(Member member, String content, String imageUrl, Long memberBookId);
 
     void deleteCard(Long memberId, Long cardId);
 

--- a/src/main/java/org/goorm/veri/veribe/domain/card/service/CardCommandServiceImpl.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/card/service/CardCommandServiceImpl.java
@@ -8,6 +8,7 @@ import org.goorm.veri.veribe.domain.card.entity.Card;
 import org.goorm.veri.veribe.domain.card.exception.CardErrorCode;
 import org.goorm.veri.veribe.domain.card.exception.CardException;
 import org.goorm.veri.veribe.domain.card.repository.CardRepository;
+import org.goorm.veri.veribe.domain.member.entity.Member;
 import org.goorm.veri.veribe.global.storage.dto.PresignedUrlRequest;
 import org.goorm.veri.veribe.global.storage.dto.PresignedUrlResponse;
 import org.goorm.veri.veribe.global.storage.service.StorageService;
@@ -32,11 +33,12 @@ public class CardCommandServiceImpl implements CardCommandService {
 
     @Transactional
     @Override
-    public Long createCard(Long memberId, String content, String imageUrl, Long memberBookId) {
+    public Long createCard(Member member, String content, String imageUrl, Long memberBookId) {
         MemberBook memberBook = memberBookRepository.findById(memberBookId)
                 .orElseThrow(() -> new CardException(BAD_REQUEST));
 
         Card card = Card.builder()
+                .member(member)
                 .content(content)
                 .image(imageUrl)
                 .memberBook(memberBook)
@@ -52,7 +54,7 @@ public class CardCommandServiceImpl implements CardCommandService {
         Card card = cardRepository.findById(cardId)
                 .orElseThrow(() -> new CardException(NOT_FOUND));
 
-        if (!card.getMemberBook().getMember().getId().equals(memberId)) {
+        if (!card.getMember().getId().equals(memberId)) {
             throw new CardException(FORBIDDEN);
         }
 
@@ -64,7 +66,7 @@ public class CardCommandServiceImpl implements CardCommandService {
         int expirationMinutes = 5;
         String prefix = "public";
 
-        if(request.contentLength() > MB) {
+        if (request.contentLength() > MB) {
             throw new CardException(CardErrorCode.IMAGE_TOO_LARGE);
         }
 

--- a/src/main/java/org/goorm/veri/veribe/domain/image/controller/ImageController.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/image/controller/ImageController.java
@@ -15,10 +15,12 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
 
-
+@Tag(name = "이미지 API")
 @RestController
 @RequestMapping("/api/v0/images")
 @RequiredArgsConstructor
@@ -26,6 +28,7 @@ public class ImageController {
     public final ImageCommandService imageCmdService;
     public final ImageQueryService imageQueryService;
 
+    @Operation(summary = "이미지 OCR 처리 및 저장", description = "이미지 URL을 받아 OCR을 수행하고 결과를 저장합니다.")
     @PostMapping("/ocr")
     public DefaultResponse<String> ocrImage(
             @AuthenticatedMember Member member,
@@ -34,6 +37,7 @@ public class ImageController {
         return DefaultResponse.ok(imageCmdService.processImageOcrAndSave(imageUrl, member));
     }
 
+    @Operation(summary = "업로드 이미지 목록 조회", description = "내가 업로드한 이미지 파일 목록을 페이지네이션으로 조회합니다.")
     @GetMapping
     public DefaultResponse<PageResponse<List<String>>> getImageFiles(
             @RequestParam(defaultValue = "1") @Min(value = 1) int page,

--- a/src/main/java/org/goorm/veri/veribe/domain/image/controller/ImageController.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/image/controller/ImageController.java
@@ -37,10 +37,10 @@ public class ImageController {
     @GetMapping
     public DefaultResponse<PageResponse<List<String>>> getImageFiles(
             @RequestParam(defaultValue = "1") @Min(value = 1) int page,
-            @RequestParam(defaultValue = "5") @Min(value = 1) int size
+            @RequestParam(defaultValue = "5") @Min(value = 1) int size,
+            @AuthenticatedMember Member member
     ) {
-        // TODO: 인증 정보 도입
         Pageable pageable = PageRequest.of(page - 1, size); // 백 페이지네이션 시에는 1-based index 를 0으로 보정.
-        return DefaultResponse.ok(imageQueryService.fetchUploadedImages(1L, pageable));
+        return DefaultResponse.ok(imageQueryService.fetchUploadedImages(member.getId(), pageable));
     }
 }

--- a/src/main/java/org/goorm/veri/veribe/domain/member/controller/MemberController.java
+++ b/src/main/java/org/goorm/veri/veribe/domain/member/controller/MemberController.java
@@ -9,7 +9,10 @@ import org.namul.api.payload.response.DefaultResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
+@Tag(name = "멤버 API")
 @RestController
 @RequestMapping("/api/v1/members")
 @RequiredArgsConstructor
@@ -17,6 +20,7 @@ public class MemberController {
 
     private final MemberQueryService memberQueryService;
 
+    @Operation(summary = "내 정보 조회", description = "로그인한 사용자의 정보를 조회합니다.")
     @GetMapping("/me")
     public DefaultResponse<MemberResponse.MemberInfoResponse> myInfo(@AuthenticatedMember Member member) {
         MemberResponse.MemberInfoResponse response = memberQueryService.findMyInfo(member);


### PR DESCRIPTION
- 카드 조회에 생성 시간 추가
- 카드 상세 조회에 memberBookId 추가

### 기타
1. MemberBook 경고 수정 
    - MemberBook 에서 카드 리스트 빌더 기본값 지정
    - 불필요한 옵션 제거 (이후 연관관계 동기화 메서드 추가 필요
2. 책장 api v2 추가  (@ojy0903  확인해주세용)
    - 쿼리파라미터로 입력받던 id 경로변수로 수정
    - API 경로를 보다 자연스럽게 수정
    - 이번주의 인기 책 API 페이징 제거, 항상 상위 10개 응답 -> 기존 v0 에서 조회 불가
3. 이미지 조회 api 에 인증 정보 사용
4. 스웨거에 설명 추가

Close #34 #35